### PR TITLE
remove beta tags for en phonecall, da, es, pt, hi

### DIFF
--- a/developers/src/pages/api-reference/transcription.mdx
+++ b/developers/src/pages/api-reference/transcription.mdx
@@ -87,7 +87,7 @@ Deepgram does not store transcriptions. Make sure to save output or [return tran
 				
 				Optimized for low-bandwidth audio phone calls.
 				
-				<strong class="hint notranslate">TIERS:</strong> enhanced <em>beta</em>, base
+				<strong class="hint notranslate">TIERS:</strong> enhanced, base
 			</li>
 			<li class="notranslate feature-item">
 				<strong>voicemail:</strong>
@@ -102,7 +102,7 @@ Deepgram does not store transcriptions. Make sure to save output or [return tran
 				
 				Optimized for multiple speakers with varying audio quality, such as might be found on a typical earnings call. Vocabulary is heavily finance oriented.
 				
-				<strong class="hint notranslate">TIERS:</strong> enhanced <em>beta</em>, base
+				<strong class="hint notranslate">TIERS:</strong> enhanced, base
 			</li>
 			<li class="notranslate feature-item">
 				<strong>conversationalai:</strong>
@@ -191,7 +191,7 @@ Deepgram does not store transcriptions. Make sure to save output or [return tran
 		</p>
 		<ul>
 			<li>
-				<strong>da:</strong> <em>beta</em>
+				<strong>da:</strong>
 				
 				<strong class="hint notranslate">MODELS:</strong> general (enhanced, base)
 			</li>
@@ -213,8 +213,8 @@ Deepgram does not store transcriptions. Make sure to save output or [return tran
 			<li>
 				<strong>en:</strong> English (Default)
 				
-				<strong class="hint notranslate">MODELS:</strong> general (enhanced, base), meeting (enhanced <em>beta</em>, base), phonecall (enhanced <em>beta</em>, base), voicemail,
-				finance (enhanced <em>beta</em>, base), conversationalai, video
+				<strong class="hint notranslate">MODELS:</strong> general (enhanced, base), meeting (enhanced <em>beta</em>, base), phonecall (enhanced, base), voicemail,
+				finance (enhanced, base), conversationalai, video
 			</li>
 			<li>
 				<strong>en-AU:</strong> Australia
@@ -239,7 +239,7 @@ Deepgram does not store transcriptions. Make sure to save output or [return tran
 			<li>
 				<strong>en-US:</strong> United States
 				
-				<strong class="hint notranslate">MODELS:</strong> general (enhanced, base), meeting (enhanced <em>beta</em>, base), phonecall (enhanced <em>beta</em>, base), voicemail,
+				<strong class="hint notranslate">MODELS:</strong> general (enhanced, base), meeting (enhanced <em>beta</em>, base), phonecall (enhanced, base), voicemail,
 				finance, conversationalai, video
 			</li>
 		</ul>
@@ -288,7 +288,7 @@ Deepgram does not store transcriptions. Make sure to save output or [return tran
 				<strong class="hint notranslate">MODELS:</strong> general
 			</li>
 			<li>
-				<strong>hi-Latn:</strong> Roman Script <em>beta</em>
+				<strong>hi-Latn:</strong> Roman Script
 				
 				<strong class="hint notranslate">MODELS:</strong> general
 			</li>
@@ -380,7 +380,7 @@ Deepgram does not store transcriptions. Make sure to save output or [return tran
 			<li>
 				<strong>es:</strong>
 				
-				<strong class="hint notranslate">MODELS:</strong> general (enhanced <em>beta</em>, base)
+				<strong class="hint notranslate">MODELS:</strong> general (enhanced, base)
 			</li>
 			<li>
 				<strong>es-419:</strong> Latin America
@@ -1318,7 +1318,7 @@ Deepgram does not store transcriptions. Make sure to save output or [return tran
 				
 				Optimized for low-bandwidth audio phone calls.
 				
-				<strong class="hint notranslate">TIERS:</strong> enhanced <em>beta</em>, base
+				<strong class="hint notranslate">TIERS:</strong> enhanced, base
 			</li>
 			<li class="notranslate feature-item">
 				<strong>voicemail:</strong>
@@ -1333,7 +1333,7 @@ Deepgram does not store transcriptions. Make sure to save output or [return tran
 				
 				Optimized for multiple speakers with varying audio quality, such as might be found on a typical earnings call. Vocabulary is heavily finance oriented.
 				
-				<strong class="hint notranslate">TIERS:</strong> enhanced <em>beta</em>, base
+				<strong class="hint notranslate">TIERS:</strong> enhanced, base
 			</li>
 			<li class="notranslate feature-item">
 				<strong>conversationalai:</strong>
@@ -1422,7 +1422,7 @@ Deepgram does not store transcriptions. Make sure to save output or [return tran
 		</p>
 		<ul>
 			<li>
-				<strong>da:</strong> <em>beta</em>
+				<strong>da:</strong>
 				
 				<strong class="hint notranslate">MODELS:</strong> general (enhanced, base)
 			</li>
@@ -1444,8 +1444,8 @@ Deepgram does not store transcriptions. Make sure to save output or [return tran
 			<li>
 				<strong>en:</strong> English (Default)
 				
-				<strong class="hint notranslate">MODELS:</strong> general (enhanced, base), meeting (enhanced <em>beta</em>, base), phonecall (enhanced <em>beta</em>, base), voicemail,
-				finance (enhanced <em>beta</em>, base), conversationalai, video
+				<strong class="hint notranslate">MODELS:</strong> general (enhanced, base), meeting (enhanced <em>beta</em>, base), phonecall (enhanced, base), voicemail,
+				finance (enhanced, base), conversationalai, video
 			</li>
 			<li>
 				<strong>en-AU:</strong> Australia
@@ -1470,7 +1470,7 @@ Deepgram does not store transcriptions. Make sure to save output or [return tran
 			<li>
 				<strong>en-US:</strong> United States
 				
-				<strong class="hint notranslate">MODELS:</strong> general (enhanced, base), meeting (enhanced <em>beta</em>, base), phonecall (enhanced <em>beta</em>, base), voicemail,
+				<strong class="hint notranslate">MODELS:</strong> general (enhanced, base), meeting (enhanced <em>beta</em>, base), phonecall (enhanced, base), voicemail,
 				finance, conversationalai, video
 			</li>
 		</ul>
@@ -1519,7 +1519,7 @@ Deepgram does not store transcriptions. Make sure to save output or [return tran
 				<strong class="hint notranslate">MODELS:</strong> general
 			</li>
 			<li>
-				<strong>hi-Latn:</strong> Roman Script <em>beta</em>
+				<strong>hi-Latn:</strong> Roman Script
 				
 				<strong class="hint notranslate">MODELS:</strong> general
 			</li>
@@ -1621,7 +1621,7 @@ Deepgram does not store transcriptions. Make sure to save output or [return tran
 			<li>
 				<strong>es:</strong>
 				
-				<strong class="hint notranslate">MODELS:</strong> general (enhanced <em>beta</em>, base)
+				<strong class="hint notranslate">MODELS:</strong> general (enhanced, base)
 			</li>
 			<li>
 				<strong>es-419:</strong> Latin America

--- a/developers/src/pages/documentation/features/language/index.mdx
+++ b/developers/src/pages/documentation/features/language/index.mdx
@@ -67,32 +67,32 @@ The following language/model combinations are supported:
 | **Chinese**                                  | `zh` *beta*      | `general`         | `base`  |
 |&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;China           | `zh-CN` *beta*   | `general`         | `base`  |
 |&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Taiwan          | `zh-TW` *beta*   | `general`         | `base`  |
-| **Danish**                                   | `da` *beta*      | `general`         | `enhanced`, `base`  |
+| **Danish**                                   | `da`             | `general`         | `enhanced`, `base`  |
 | **Dutch**                                    | `nl` *beta*      | `general`         | `enhanced`, `base`  |
-| **English**                                  | `en`             | `general`<br/>`meeting`<br/>`phonecall`<br/>`voicemail`<br/>`finance`<br/>`conversationalai`<br/>`video`  | `enhanced`, `base`<br/>`enhanced` *beta*, `base`<br/>`enhanced` *beta*, `base`<br/>`base`<br/>`enhanced` *beta*,`base`<br/>`base`<br/>`base` |
+| **English**                                  | `en`             | `general`<br/>`meeting`<br/>`phonecall`<br/>`voicemail`<br/>`finance`<br/>`conversationalai`<br/>`video`  | `enhanced`, `base`<br/>`enhanced` *beta*, `base`<br/>`enhanced`, `base`<br/>`base`<br/>`enhanced`,`base`<br/>`base`<br/>`base` |
 |&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Australia       | `en-AU`          | `general`         | `base` |
 |&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;United Kingdom  | `en-GB`          | `general`         | `base` |
 |&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;India           | `en-IN`          | `general`         | `base` |
 |&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;New Zealand     | `en-NZ`          | `general`         | `base` |
-|&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;United States   | `en-US`          | `general`<br/>`meeting`<br/>`phonecall`<br/>`voicemail`<br/>`finance`<br/>`conversationalai`<br/>`video`  | `enhanced`, `base`<br/>`enhanced` *beta*, `base`<br/>`enhanced` *beta*, `base`<br/>`base`<br/>`enhanced` *beta*, `base`<br/>`base`<br/>`base` |
+|&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;United States   | `en-US`          | `general`<br/>`meeting`<br/>`phonecall`<br/>`voicemail`<br/>`finance`<br/>`conversationalai`<br/>`video`  | `enhanced`, `base`<br/>`enhanced` *beta*, `base`<br/>`enhanced`, `base`<br/>`base`<br/>`enhanced`, `base`<br/>`base`<br/>`base` |
 | **Flemish**                                  | `nl` *beta*      | `general`         | `enhanced`, `base` |
 | **French**                                   | `fr`             | `general`         | `enhanced` *beta*, `base` |
 |&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Canada          | `fr-CA`          | `general`         | `base` |
 | **German**                                   | `de`             | `general`         | `enhanced` *beta*, `base` |
-| **Hindi**                                    | `hi`             | `general`         | `enhanced` *beta*, `base` |
-|&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Roman Script    | `hi-Latn` *beta* | `general`         | `base` |
+| **Hindi**                                    | `hi`             | `general`         | `enhanced`, `base` |
+|&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Roman Script    | `hi-Latn`        | `general`         | `base` |
 | **Indonesian**                               | `id` *beta*      | `general`         | `base` |
 | **Italian**                                  | `it` *beta*      | `general`         | `enhanced`, `base` |
 | **Japanese**                                 | `ja` *beta*      | `general`         | `enhanced`, `base` |
 | **Korean**                                   | `ko` *beta*      | `general`         | `enhanced`, `base` |
 | **Norwegian**                                | `no` *beta*      | `general`         | `enhanced`, `base` |
 | **Polish**                                   | `pl` *beta*      | `general`         | `enhanced`, `base` |
-| **Portuguese**                               | `pt`             | `general`         | `enhanced` *beta*, `base` |
-|&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Brazil          | `pt-BR`          | `general`         | `enhanced` *beta*, `base` |
-|&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Portugal        | `pt-PT`          | `general`         | `enhanced` *beta*, `base` |
+| **Portuguese**                               | `pt`             | `general`         | `enhanced`, `base` |
+|&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Brazil          | `pt-BR`          | `general`         | `enhanced`, `base` |
+|&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Portugal        | `pt-PT`          | `general`         | `enhanced`, `base` |
 | **Russian**                                  | `ru`             | `general`         | `base` |
-| **Spanish**                                  | `es`             | `general`         | `enhanced` *beta*, `base` |
-|&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Latin America   | `es-419`         | `general`         | `enhanced` *beta*, `base` |
+| **Spanish**                                  | `es`             | `general`         | `enhanced`, `base` |
+|&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Latin America   | `es-419`         | `general`         | `enhanced`, `base` |
 | **Swedish**                                  | `sv` *beta*      | `general`         | `enhanced`, `base` |
 | **Tamil**                                    | `ta` *beta*      | `general`         | `enhanced` |
 | **Turkish**                                  | `tr`             | `general`         | `base` |


### PR DESCRIPTION
Remove beta tags for en phonecall, da, es, pt, hi based on costumer adoption until formal process is created.