### PR TITLE
Adding a preceeding slash to 'compare-nuance-dragon...'

### DIFF
--- a/shared/src/shared/components/layout/Header.astro
+++ b/shared/src/shared/components/layout/Header.astro
@@ -90,7 +90,7 @@ const { WWW_DOMAIN, DOCS_DOMAIN, BLOG_DOMAIN, CONSOLE_DOMAIN, STATUS_DOMAIN } = 
 						<NavMenuItem href={`${WWW_DOMAIN}/compare-google-stt-alternatives/`} icon="scale">Compare to Google STT</NavMenuItem>
 						<NavMenuItem href={`${WWW_DOMAIN}/compare-amazon-transcribe-api-alternatives/`} icon="scale">Compare to AWS Transcribe</NavMenuItem>
 						<NavMenuItem href={`${WWW_DOMAIN}/compare-microsoft-azure-stt-alternatives/`} icon="scale">Compare to Microsoft STT</NavMenuItem>
-						<NavMenuItem href={`${WWW_DOMAIN}compare-nuance-dragon-speech-recognition-alternatives/`} icon="scale">Compare to Nuance Dragon</NavMenuItem>
+						<NavMenuItem href={`${WWW_DOMAIN}/compare-nuance-dragon-speech-recognition-alternatives/`} icon="scale">Compare to Nuance Dragon</NavMenuItem>
 						<NavMenuItem href={`${WWW_DOMAIN}/compare-assembly-ai-speech-to-text-api-alternatives/`} icon="scale">Compare to Assembly AI</NavMenuItem>
 						<NavMenuItem href={`${WWW_DOMAIN}/compare-speechmatics-speech-to-text-api-alternatives/`} icon="scale">Compare to Speechmatics</NavMenuItem>
 					</NavMenu>


### PR DESCRIPTION
There was a typo where an href was pointing to 
`https://deepgram.comcompare-nuance-dragon-speech-recognition-alternatives/` instead of `https://deepgram.com/compare-nuance-dragon-speech-recognition-alternatives/`