### PR TITLE
clarify profanity filter is only available for base

### DIFF
--- a/developers/src/pages/documentation/features/profanity-filter/index.mdx
+++ b/developers/src/pages/documentation/features/profanity-filter/index.mdx
@@ -22,7 +22,7 @@ Deepgram’s Profanity Filter feature looks for recognized profanity and convert
 
 <Alert type="warning">
 
-This feature is available for English only ([all available regions](/documentation/features/language/#enable-feature)).
+This feature is available for English only ([all available regions](/documentation/features/language/#enable-feature)) and [base tier](/documentation/features/model/#base) models only.
 
 </Alert>
 


### PR DESCRIPTION
Adds a compatibility flag instead of removing the docs altogether.