### PR TITLE
Updating the curl command to work with SPA update earlier this year

### DIFF
--- a/developers/src/pages/documentation/guides/measure-latency/index.mdx
+++ b/developers/src/pages/documentation/guides/measure-latency/index.mdx
@@ -42,7 +42,7 @@ For security purposes, Deepgram blocks pings; instead, for a more realistic meas
 <CodeBlock tab="shell" active>
 
 ```sh
-curl -sSf -o /dev/null -w '%{time_connect}\n' api.deepgram.com
+curl -sSf -o /dev/null -w '%{time_connect}\n' "https://api.deepgram.com"
 0.111473
 ```
 


### PR DESCRIPTION
The existing command implicitly uses port 80 which is no longer open after the service-provider-architecure (SPA) update.  Setting to "https" to ensure curl gets a response.
Discussion: https://deepgram.slack.com/archives/C04PQ55TKST/p1683839953678809?thread_ts=1683838269.052869&cid=C04PQ55TKST